### PR TITLE
Adding user association to posts in posts list

### DIFF
--- a/app/assets/javascripts/components/post_item.es6.jsx
+++ b/app/assets/javascripts/components/post_item.es6.jsx
@@ -1,6 +1,6 @@
 class PostItem extends React.Component {
   render () {
-    let {post, user} = this.props;
+    let {post,user} = this.props;
     let cts = this.props.post.created_at;
     let cdate = (new Date(cts)).toDateString();
     return (

--- a/app/assets/javascripts/components/post_list.es6.jsx
+++ b/app/assets/javascripts/components/post_list.es6.jsx
@@ -1,6 +1,7 @@
 class PostList extends React.Component {
   render () {
-  let {posts, user} = this.props;
+  let {posts} = this.props;
+
     return (
       <div className="container">
         <table className="table forum table-striped">
@@ -8,7 +9,7 @@ class PostList extends React.Component {
           <ListHeader />
           <tbody>
             {this.props.posts.map((post, index) => {
-              return (<PostItem post={post} user={user}/>);
+              return (<PostItem post={post} user={post.user} />);
             })}
           </tbody>
         </table>

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,7 +1,7 @@
 class WelcomeController < ApplicationController
   def index
-    @posts = Post.all.reverse
-    @user = User.find_by(params[:user_id])
-    render component: 'PostList', props: {posts: @posts, user: @user}
+    @posts = Post.includes(:user).reverse.map {|post| post.attributes.merge!({user: {image_url: post.user.image_url, nickname: post.user.nickname}})}
+    byebug
+    render component: 'PostList', props: {posts: @posts}
   end
 end


### PR DESCRIPTION
Fixes user nickname in posts list being set to current user. Probably a more efficient way to lookup user for each post, but this does the trick. Might be good to move that lookup into a scope on the Post model.